### PR TITLE
Allow bounds on type parameters

### DIFF
--- a/processor/src/main/java/org/derive4j/processor/AdtParser.java
+++ b/processor/src/main/java/org/derive4j/processor/AdtParser.java
@@ -95,9 +95,8 @@ public final class AdtParser implements DeriveUtils {
         error(message("Invalid annotated class (only static classes are supported)", onElement(adtTypeElement))),
 
         declaredType ->
-            fold(traverseOptional(declaredType.getTypeArguments(), ta -> asTypeVariable.visit(ta)
-                    .filter(tv -> types.isSameType(elements.getTypeElement("java.lang.Object").asType(), tv.getUpperBound()))),
-                error(message("Please use only type variable without bounds as type parameter", onElement(adtTypeElement))),
+            fold(traverseOptional(declaredType.getTypeArguments(), asTypeVariable::visit),
+                error(message("Please use only type variable as type parameter", onElement(adtTypeElement))),
 
                 adtTypeVariables ->
                     fold(findOnlyOne(getAbstractMethods(adtTypeElement.getEnclosedElements()).stream()


### PR DESCRIPTION
First of all, thanks for this wonderful project!

It would be nice if derive4j didn't impose the restriction that type variables for data classes must not be bounded. I tried implementing a couple heap data structures from Purely Functional Data Structures using derive4j and quickly ran into this problem because I wanted the elements of the heap to be comparable. See here for an example:

https://github.com/datatyped/pfds-java/blob/master/src/main/java/com/datatyped/LeftistHeap.java

I don't see any fundamental reason why this should not be allowed -- all that actually needs to change is that the TotalMatchBuilder singleton should use wildcards rather than Object to play nice with bounded type variables.