### PR TITLE
Adds io.vavr support, fixing #71

### DIFF
--- a/annotation/src/main/java/org/derive4j/Flavour.java
+++ b/annotation/src/main/java/org/derive4j/Flavour.java
@@ -61,6 +61,14 @@ public enum Flavour {
     }
   },
 
+  Vavr {
+    @Override
+    public <R> R match(Cases<R> cases) {
+
+      return cases.Vavr();
+    }
+  },
+
   HighJ {
     @Override
     public <R> R match(Cases<R> cases) {
@@ -87,6 +95,8 @@ public enum Flavour {
     R Fugue2();
 
     R Javaslang();
+
+    R Vavr();
 
     R HighJ();
 

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ allprojects {
 
     ext {
         isSnapshot = true
-        d4jBaseVersion = "0.12.2"
+        d4jBaseVersion = "0.12.3"
 
         snapshotAppendix = "-SNAPSHOT"
         d4jVersion = d4jBaseVersion + (isSnapshot ? snapshotAppendix : "")

--- a/processor/src/main/java/org/derive4j/processor/DeriveUtilsImpl.java
+++ b/processor/src/main/java/org/derive4j/processor/DeriveUtilsImpl.java
@@ -170,6 +170,7 @@ final class DeriveUtilsImpl implements DeriveUtils {
         .Fugue_(jdkSupplier)
         .Fugue2_(guavaSupplier)
         .Javaslang_(jdkSupplier)
+        .Vavr_(jdkSupplier)
         .HighJ_(jdkSupplier)
         .Guava_(guavaSupplier);
 
@@ -182,6 +183,7 @@ final class DeriveUtilsImpl implements DeriveUtils {
         .Fugue_(jdkFunction)
         .Fugue2_(guavaFunction)
         .Javaslang_(lazySamInterface("javaslang.Function1"))
+        .Vavr_(lazySamInterface("io.vavr.Function1"))
         .HighJ_(lazySamInterface("org.highj.function.F1"))
         .Guava_(guavaFunction);
 
@@ -191,6 +193,7 @@ final class DeriveUtilsImpl implements DeriveUtils {
         .Fugue_(lazyOptionModel("io.atlassian.fugue.Option", "none", "some"))
         .Fugue2_(lazyOptionModel("com.atlassian.fugue.Option", "none", "some"))
         .Javaslang_(lazyOptionModel("javaslang.control.Option", "none", "some"))
+        .Vavr_(lazyOptionModel("io.vavr.control.Option", "none", "some"))
         .HighJ_(lazyOptionModel("org.highj.data.Maybe", "Nothing", "Just"))
         .Guava_(lazyOptionModel("com.google.common.base.Optional", "absent", "of"));
 
@@ -200,6 +203,7 @@ final class DeriveUtilsImpl implements DeriveUtils {
         .Fugue_(eitherModel("io.atlassian.fugue.Either", "left", "right"))
         .Fugue2_(eitherModel("com.atlassian.fugue.Either", "left", "right"))
         .Javaslang_(eitherModel("javaslang.control.Either", "left", "right"))
+        .Vavr_(eitherModel("io.vavr.control.Either", "left", "right"))
         .HighJ_(eitherModel("org.highj.data.Either", "Left", "Right"))
         .Guava_(Optional.empty());
   }


### PR DESCRIPTION
Adds new `Vavr` flavour and adds the related mappings.

I'm not overly familiar with Gradle so havn't tested this against my maven projects yet. Can one easily deploy the equivalent of a `-SNAPSHOT` into the local repo?