### PR TITLE
Add Generated annotation to generated classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,13 @@
 target
 out
 lib_managed
-*.iws
 .deps
 .idea
 .gradle
 build
 *.iml
+*.ipr
+*.iws
 .settings
 .classpath
 .project

--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ allprojects {
         dependencyJavaPoet = "com.squareup:javapoet:1.11.1"
         dependencyPreviousDerive4J = "org.derive4j:derive4j:1.1.0"
         dependencyJunit = "junit:junit:4.12"
-        dependencyAutoService = "com.google.auto.service:auto-service:1.0-rc4"
+        dependencyAutoService = "com.google.auto.service:auto-service:1.0-rc5"
 
         gplLicenseName = "The GNU General Public License"
         lgplLicenseName = "The GNU Lesser General Public License"
@@ -75,7 +75,7 @@ allprojects {
 
     version = d4jVersion
     group = "org.derive4j"
-    
+
 }
 
 artifactoryPublish.skip = true
@@ -97,7 +97,7 @@ subprojects {
             endWithNewline()
         }
     }
-    
+
 
     repositories {
         mavenLocal()

--- a/processor/build.gradle
+++ b/processor/build.gradle
@@ -6,7 +6,7 @@ dependencies {
   compile project(":annotation")
   compile project(":processor-api")
   compile dependencyJavaPoet
-  compileOnly dependencyAutoService
+  compile dependencyAutoService
   annotationProcessor dependencyAutoService
   annotationProcessor dependencyPreviousDerive4J
   testCompile dependencyJunit

--- a/processor/src/main/java/org/derive4j/processor/DeriveUtilsImpl.java
+++ b/processor/src/main/java/org/derive4j/processor/DeriveUtilsImpl.java
@@ -18,6 +18,7 @@
  */
 package org.derive4j.processor;
 
+import com.google.auto.common.GeneratedAnnotations;
 import com.squareup.javapoet.AnnotationSpec;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.CodeBlock;
@@ -42,6 +43,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
+import javax.lang.model.SourceVersion;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
@@ -145,6 +147,7 @@ final class DeriveUtilsImpl implements DeriveUtils {
 
   private final Elements            Elements;
   private final Types               Types;
+  private final SourceVersion       SourceVersion;
   private final DeriveConfigBuilder deriveConfigBuilder;
   private final ObjectModel         objectModel;
 
@@ -153,10 +156,12 @@ final class DeriveUtilsImpl implements DeriveUtils {
   private final Function<Flavour, OptionModel>           optionModel;
   private final Function<Flavour, Optional<EitherModel>> eitherModel;
 
-  DeriveUtilsImpl(Elements Elements, Types Types, DeriveConfigBuilder deriveConfigBuilder) {
+  DeriveUtilsImpl(
+      Elements Elements, Types Types, SourceVersion SourceVersion, DeriveConfigBuilder deriveConfigBuilder) {
 
     this.Elements = Elements;
     this.Types = Types;
+    this.SourceVersion = SourceVersion;
     this.deriveConfigBuilder = deriveConfigBuilder;
 
     TypeElement object = Elements.getTypeElement(Object.class.getName());
@@ -381,6 +386,10 @@ final class DeriveUtilsImpl implements DeriveUtils {
   @Override
   public Optional<TypeElement> asTypeElement(TypeMirror typeMirror) {
     return asDeclaredType(typeMirror).map(DeclaredType::asElement).flatMap(asTypeElement::visit);
+  }
+
+  public Optional<TypeElement> generatedAnnotation() {
+    return GeneratedAnnotations.generatedAnnotation(Elements, SourceVersion);
   }
 
   @Override

--- a/processor/src/main/java/org/derive4j/processor/DerivingProcessor.java
+++ b/processor/src/main/java/org/derive4j/processor/DerivingProcessor.java
@@ -19,6 +19,7 @@
 package org.derive4j.processor;
 
 import com.google.auto.service.AutoService;
+import com.squareup.javapoet.AnnotationSpec;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.JavaFile;
 import com.squareup.javapoet.MethodSpec;
@@ -104,7 +105,10 @@ public final class DerivingProcessor extends AbstractProcessor {
 
     deriveConfigBuilder = new DeriveConfigBuilder(processingEnv.getElementUtils());
 
-    deriveUtils = new DeriveUtilsImpl(processingEnv.getElementUtils(), processingEnv.getTypeUtils(),
+    deriveUtils = new DeriveUtilsImpl(
+        processingEnv.getElementUtils(),
+        processingEnv.getTypeUtils(),
+        processingEnv.getSourceVersion(),
         deriveConfigBuilder);
     builtinDerivator = BuiltinDerivator.derivator(deriveUtils);
     adtParser = new AdtParser(deriveUtils);
@@ -222,6 +226,11 @@ public final class DerivingProcessor extends AbstractProcessor {
         .addTypes(getClasses(codeSpec))
         .addFields(getFields(codeSpec))
         .addMethods(getMethods(codeSpec));
+
+    deriveUtils.generatedAnnotation()
+        .ifPresent(annotation -> builder.addAnnotation(AnnotationSpec.builder(ClassName.get(annotation))
+            .addMember("value", "$S", getClass().getCanonicalName())
+            .build()));
 
     deriveConfig.targetClass().extend().ifPresent(cn -> {
       if (deriveUtils.findTypeElement(cn).get().getKind().isInterface()) {

--- a/processor/src/test/java/org/derive4j/processor/DeriveUtilsImplTest.java
+++ b/processor/src/test/java/org/derive4j/processor/DeriveUtilsImplTest.java
@@ -53,8 +53,11 @@ public class DeriveUtilsImplTest {
           public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
 
             if (!roundEnv.processingOver()) {
-              DeriveUtilsImpl deriveUtils = new DeriveUtilsImpl(processingEnv.getElementUtils(),
-                  processingEnv.getTypeUtils(), new DeriveConfigBuilder(processingEnv.getElementUtils()));
+              DeriveUtilsImpl deriveUtils = new DeriveUtilsImpl(
+                  processingEnv.getElementUtils(),
+                  processingEnv.getTypeUtils(),
+                  processingEnv.getSourceVersion(),
+                  new DeriveConfigBuilder(processingEnv.getElementUtils()));
               for (TypeElement typeElement : ElementFilter.typesIn(roundEnv.getRootElements())) {
                 List<ExecutableElement> abstractMethods = deriveUtils
                     .allAbstractMethods((DeclaredType) typeElement.asType());


### PR DESCRIPTION
This annotation is used to inform other tools that this code is generated.

For example, [error-prone](https://github.com/google/error-prone) [uses this annotation](https://github.com/google/error-prone/blob/24f4d7d148446cc33467e30947ebcef15c84bebd/check_api/src/main/java/com/google/errorprone/SuppressionInfo.java) to suppress warnings in generated code when the `XepDisableWarningsInGeneratedCode` flag is set.