### PR TITLE
workaround ecj javapoet issue

### DIFF
--- a/processor/src/main/java/org/derive4j/processor/LazyConstructorDerivator.java
+++ b/processor/src/main/java/org/derive4j/processor/LazyConstructorDerivator.java
@@ -102,7 +102,7 @@ final class LazyConstructorDerivator implements Derivator {
                 .addStatement("break")
                 .endControlFlow()
                 .beginControlFlow("else")
-                .addStatement("$T eval = expr.$L", typeName, f0.sam())
+                .addStatement("$T eval = expr.$N()", typeName, f0.sam().getSimpleName())
                 .beginControlFlow("if (eval instanceof $T)", className)
                 .addStatement("lazy = ($T) eval", lazyTypeName)
                 .endControlFlow()


### PR DESCRIPTION
In ecj, $L combined with an ExecutableElement representing Supplier#get will insert `public abstract T get() ` instead of the intended `get()`.

This could also be a bug with javapoet. I will raise an issue with them.